### PR TITLE
Increase item max level on sliders

### DIFF
--- a/AutoSeller.lua
+++ b/AutoSeller.lua
@@ -1002,7 +1002,7 @@ function SYH:ShowPanel(loadOnly)
 					SYH.db.profile.SellGreenMaxLevel = value
 				end,
 				min = 6,
-				max = 500,
+				max = 700,
 				step = 1,
 				namePhraseId = "STRING_ITEMLEVEL",
 				descPhraseId = "STRING_ITEMLEVEL_DESC2",
@@ -1016,7 +1016,7 @@ function SYH:ShowPanel(loadOnly)
 					AutoSeller.db.profile.SellEpicGearThreshold = value
 				end,
 				min = 6,
-				max = 500,
+				max = 700,
 				step = 1,
 				namePhraseId = "STRING_EPICRANGE",
 				descPhraseId = "STRING_EPICRANGE_DESC",


### PR DESCRIPTION
Item loot is now usually over 600, I think the biggest item level is something like 640 right now, but increasing the slider cap to 700 allow a little room